### PR TITLE
Fix for models within namespaces

### DIFF
--- a/app/controllers/the_sortable_tree_controller.rb
+++ b/app/controllers/the_sortable_tree_controller.rb
@@ -7,7 +7,7 @@ module TheSortableTreeController
     def the_define_common_variables
       collection =  self.class.to_s.split(':').last.sub(/Controller/,"").underscore.downcase # recipes
       variable =    collection.singularize                      # recipe
-      klass =       variable.classify.constantize               # Recipe
+      klass = self.class.to_s.sub(/Controller/,"").singularize.constantize
       ["@#{variable}", collection, klass]
     end
   end#DefineVariablesMethod


### PR DESCRIPTION
I was getting errors when trying to rebuild on a model that is namespaced such as Inventory::Category. It seemed like 'klass' ended up being only 'Category' which isn't a valid model name.
