### PR TITLE
fixed deprecated :confirm in `link_to`

### DIFF
--- a/app/views/sortable/base/_controls.html.haml
+++ b/app/views/sortable/base/_controls.html.haml
@@ -5,7 +5,7 @@
   - delete =  link_to('', url_for(opts[:namespace] + [node]),
     :title    =>  t('.delete'),
     :method   =>  :delete,
-    :confirm  =>  t('.delete_confirm'),
+    :data     => {:confirm  =>  t('.delete_confirm')},
     :class    =>  'button delete')
 - else
   - delete =  link_to('', '#',


### PR DESCRIPTION
DEPRECATION WARNING: :confirm option is deprecated and will be removed from Rails 4.0. Use ':data => { :confirm => 'Text' }' instead.
