### PR TITLE
Allow project's root in subdirectory

### DIFF
--- a/app/assets/stylesheets/sortable_tree.css.scss
+++ b/app/assets/stylesheets/sortable_tree.css.scss
@@ -42,7 +42,7 @@
   }
 
   .handle{
-    background: transparent url(/assets/iconza/icons/move.png);
+    background: transparent image-url("iconza/icons/move.png");
     background-position: center center;
 
     width: 16px;
@@ -51,7 +51,7 @@
     float: left;
     cursor: move;
 
-    &:hover{ background: transparent url(/assets/iconza/icons/red_move.png); }
+    &:hover{ background: transparent image-url("iconza/icons/red_move.png"); }
   }
 
   .item{
@@ -90,16 +90,16 @@
       overflow: hidden; zoom: 1;
 
       &.new{
-        background: transparent url(/assets/iconza/icons/add.png) no-repeat scroll center center;
-        &:hover{ background: transparent url(/assets/iconza/icons/red_add.png) no-repeat scroll center center; }
+        background: transparent image-url("iconza/icons/add.png") no-repeat scroll center center;
+        &:hover{ background: transparent image-url("iconza/icons/red_add.png") no-repeat scroll center center; }
       }
       &.edit{
-        background: transparent url(/assets/iconza/icons/edit.png) no-repeat scroll center center;
-        &:hover{ background: transparent url(/assets/iconza/icons/red_edit.png) no-repeat scroll center center; }
+        background: transparent image-url("iconza/icons/edit.png") no-repeat scroll center center;
+        &:hover{ background: transparent image-url("iconza/icons/red_edit.png") no-repeat scroll center center; }
       }
       &.delete{
-        background: transparent url(/assets/iconza/icons/delete.png) no-repeat scroll center center;
-        &:hover{ background: transparent url(/assets/iconza/icons/red_delete.png) no-repeat scroll center center; }
+        background: transparent image-url("iconza/icons/delete.png") no-repeat scroll center center;
+        &:hover{ background: transparent image-url("iconza/icons/red_delete.png") no-repeat scroll center center; }
       }
     }
   }


### PR DESCRIPTION
To allow, that the the project's root is not directly under the hostname but under a subdirectory, it is necessary that the icon references in sortable_tree.css.scss are used as

```
image-url("iconza/icons/red_add.png")
```

instead of

```
url(/assets/iconza/icons/red_add.png)
```

E.g. if the project's root is http://something.com/projectdir, image-url("iconza/icons/red_add.png") becomes url(/projectdir/iconza/icons/red_add.png).

See http://guides.rubyonrails.org/asset_pipeline.html chapter 2.2.2 CSS and Sass
