### PR TITLE
Fix namespacing issues for links in render helpers

### DIFF
--- a/app/helpers/render_expandable_tree_helper.rb
+++ b/app/helpers/render_expandable_tree_helper.rb
@@ -30,7 +30,7 @@ module RenderExpandableTreeHelper
 
       def show_link
         node = options[:node]
-        url = h.url_for(:namespace => options[:namespace], :controller => kontroller, :action => :show, :id => node)
+        url = h.url_for(:controller => kontroller, :action => :show, :id => node)
         title_field = options[:title]
 
         "<h4>#{ h.link_to(node.send(title_field), url) }</h4>"
@@ -39,8 +39,8 @@ module RenderExpandableTreeHelper
       def controls
         node = options[:node]
 
-        edit_path = h.url_for(:namespace => options[:namespace], :controller => kontroller, :action => :edit, :id => node)
-        destroy_path = h.url_for(:namespace => options[:namespace], :controller => kontroller, :action => :destroy, :id => node)
+        edit_path = h.url_for(:controller => kontroller, :action => :edit, :id => node)
+        destroy_path = h.url_for(:controller => kontroller, :action => :destroy, :id => node)
 
         "
           <div class='controls'>

--- a/app/helpers/render_sortable_tree_helper.rb
+++ b/app/helpers/render_sortable_tree_helper.rb
@@ -29,7 +29,7 @@ module RenderSortableTreeHelper
 
       def show_link
         node = options[:node]
-        url = h.url_for(:namespace => options[:namespace], :controller => kontroller, :action => :show, :id => node)
+        url = h.url_for(:controller => kontroller, :action => :show, :id => node)
         title_field = options[:title]
 
         "<h4>#{ h.link_to(node.send(title_field), url) }</h4>"
@@ -38,8 +38,8 @@ module RenderSortableTreeHelper
       def controls
         node = options[:node]
 
-        edit_path = h.url_for(:namespace => options[:namespace], :controller => kontroller, :action => :edit, :id => node)
-        destroy_path = h.url_for(:namespace => options[:namespace], :controller => kontroller, :action => :destroy, :id => node)
+        edit_path = h.url_for(:controller => kontroller, :action => :edit, :id => node)
+        destroy_path = h.url_for(:controller => kontroller, :action => :destroy, :id => node)
 
         "
           <div class='controls'>

--- a/app/helpers/render_tree_helper.rb
+++ b/app/helpers/render_tree_helper.rb
@@ -27,7 +27,7 @@ module RenderTreeHelper
 
       def show_link
         node = options[:node]
-        url = h.url_for(:namespace => options[:namespace], :controller => kontroller, :action => :show, :id => node)
+        url = h.url_for(:controller => kontroller, :action => :show, :id => node)
         title_field = options[:title]
 
         "<h4>#{ h.link_to(node.send(title_field), url) }</h4>"


### PR DESCRIPTION
- d3c0e0d8 removed the ability to use namespaces on the sortable tree helper. This reinstates that capability, but also adds consistent rendering _and_ namespacing for all render helpers.
- ce696f3a meant to clarify that a `show` link was not being used for a `delete` link, but neglected to update in all the helpers. This PR also addresses that issue.
- Actually, this PR makes each renderer consistent in how it builds links, and allows you to explicitly pass what controller you want to use for building said links.
