### PR TITLE
add indented options renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,24 +8,28 @@ Nested Set + Drag&Drop GUI. Very fast! Best render helper! **2000 nodes/sec**. R
 
 ### Dummy Application
 
-* [spec/dummy_app](https://github.com/the-teacher/the_sortable_tree/tree/master/spec/dummy_app)
-* [spec/dummy_app/README.md](https://github.com/the-teacher/the_sortable_tree/blob/master/spec/dummy_app/README.md)
+* [spec/dummy_app](spec/dummy_app)
+* [spec/dummy_app/README.md](dummy_app/README.md)
 
 ## Sortable tree. Drag&Drop GUI
 
-![Drag&Drop GUI. Sotrable tree](https://raw.github.com/the-teacher/the_sortable_tree/master/docs/sortable.jpg)
+![Drag&Drop GUI. Sotrable tree](docs/sortable.jpg)
 
 ## Render tree
 
-![Render tree](https://raw.github.com/the-teacher/the_sortable_tree/master/docs/tree.jpg)
+![Render tree](docs/tree.jpg)
 
 ## Render Nested Options
 
-![Nested options](https://raw.github.com/the-teacher/the_sortable_tree/master/docs/nested_options.jpg)
+![Nested options](docs/nested_options.jpg)
+
+## Render Indented Options
+
+![Indented options](docs/indented_options.jpg)
 
 ## Expandable tree
 
-![Expandable](https://raw.github.com/the-teacher/the_sortable_tree/master/docs/expandable.jpg)
+![Expandable](docs/expandable.jpg)
 
 ## Keywords
 
@@ -148,6 +152,8 @@ build_server_tree(tree, options)
 
 **nested_options** is just alias of **build_server_tree(tree, type: :nested_options)**
 
+This uses CSS styling, for indenting with spaces, use **indented_options** instead.
+
 
 ## build_server_tree options
 
@@ -182,9 +188,10 @@ Options list:
 
 1. **id** - id field of node
 2. **title** - title field of node
-3. **type** - type of tree [tree|sortable|nested_options]
+3. **type** - type of tree [tree|sortable|nested_options|indented_options]
 4. **namespace** - for example: **:admin**. **[]** - by default
 5. **render_module** - your own Render Tree Helper
+6. **spacing** - number of spaces per level (indented_options only)
 
 **Rendering runtime params (see code of render helpers):**
 

--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Render helpers for HTML tree generation
 bundle exec rails g the_sortable_tree:views tree
 bundle exec rails g the_sortable_tree:views sortable
 bundle exec rails g the_sortable_tree:views nested_options
+bundle exec rails g the_sortable_tree:views indented_options
 ```
 
 Base Render helper of gem

--- a/app/helpers/render_indented_options_helper.rb
+++ b/app/helpers/render_indented_options_helper.rb
@@ -1,0 +1,24 @@
+module RenderIndentedOptionsHelper
+  class Render
+    class << self
+      attr_accessor :h, :options
+
+      def render_node(h, options)
+        @h, @options = h, options
+
+        node = options[:node]
+        spacing = (options[:spacing] || 3).to_i
+
+        html_options = {value: node.id}
+        if options[:selected] == node
+          html_options[:selected] = 'selected'
+          html_options[:class] = 'selected'
+        end
+        title = "\u202f" * spacing * (options[:level]-1) + node.send(options[:title])
+
+        h.content_tag(:option, title, html_options) + options[:children].html_safe
+      end
+
+    end
+  end
+end

--- a/app/helpers/the_sortable_tree_helper.rb
+++ b/app/helpers/the_sortable_tree_helper.rb
@@ -10,7 +10,8 @@ module TheSortableTreeHelper
     :tree     => RenderTreeHelper,
     :sortable => RenderSortableTreeHelper,
     :expandable => RenderExpandableTreeHelper,
-    :nested_options => RenderNestedOptionsHelper
+    :nested_options => RenderNestedOptionsHelper,
+    :indented_options => RenderIndentedOptionsHelper
   }
 
   ###############################################
@@ -43,6 +44,10 @@ module TheSortableTreeHelper
 
   def nested_options tree, options = {}
     build_server_tree(tree, { :type => :nested_options }.merge!(options))
+  end
+
+  def indented_options tree, options = {}
+    build_server_tree(tree, { :type => :indented_options }.merge!(options))
   end
 
   def expandable_tree tree, options = {}

--- a/lib/generators/the_sortable_tree/views_generator.rb
+++ b/lib/generators/the_sortable_tree/views_generator.rb
@@ -9,6 +9,7 @@ module TheSortableTree
 bundle exec rails g the_sortable_tree:views tree
 bundle exec rails g the_sortable_tree:views sortable
 bundle exec rails g the_sortable_tree:views nested_options
+bundle exec rails g the_sortable_tree:views indented_options
 
 bundle exec rails g the_sortable_tree:views helper
 
@@ -37,6 +38,9 @@ BANNER
         elsif param_name == 'nested_options'
           puts "Copy of nested options tree render helper file"
           copy_file "../helpers/render_nested_options_helper.rb", "app/helpers/render_nested_options_helper.rb"
+        elsif param_name == 'indented_options'
+          puts "Copy of indented options tree render helper file"
+          copy_file "../helpers/render_indented_options_helper.rb", "app/helpers/render_indented_options_helper.rb"
         elsif param_name == 'helper'
           puts "Copy of base nested set render helper file"
           copy_file "../helpers/the_sortable_tree_helper.rb", "app/helpers/the_sortable_tree_helper.rb"

--- a/spec/dummy_app/app/controllers/admin/pages_controller.rb
+++ b/spec/dummy_app/app/controllers/admin/pages_controller.rb
@@ -13,6 +13,10 @@ class Admin::PagesController < ApplicationController
     @pages = Admin::Page.nested_set.select('id, title, content, parent_id').limit(15)
   end
 
+  def indented_options
+    @pages = Admin::Page.nested_set.select('id, title, content, parent_id').limit(15)
+  end
+
   def node_manage
     @root  = Admin::Page.root
     @pages = @root.self_and_descendants.nested_set.select('id, title, content, parent_id').limit(15)

--- a/spec/dummy_app/app/controllers/pages_controller.rb
+++ b/spec/dummy_app/app/controllers/pages_controller.rb
@@ -10,6 +10,10 @@ class PagesController < ApplicationController
     @pages = Page.nested_set.select('id, title, content, parent_id').limit(15)
   end
 
+  def indented_options
+    @pages = Page.nested_set.select('id, title, content, parent_id').limit(15)
+  end
+
   def manage
     @pages = Page.nested_set.select('id, title, content, parent_id').all
   end

--- a/spec/dummy_app/app/views/admin/pages/indented_options.html.haml
+++ b/spec/dummy_app/app/views/admin/pages/indented_options.html.haml
@@ -1,0 +1,3 @@
+%p= link_to raw('&larr; back'), '/'
+
+= select_tag :pages, indented_options(@pages, selected: @pages.last), class: :nested_options

--- a/spec/dummy_app/app/views/pages/indented_options.html.haml
+++ b/spec/dummy_app/app/views/pages/indented_options.html.haml
@@ -1,0 +1,3 @@
+%p= link_to raw('&larr; back'), '/'
+
+= select_tag :pages, indented_options(@pages, selected: @pages.last)

--- a/spec/dummy_app/app/views/welcome/index.html.haml
+++ b/spec/dummy_app/app/views/welcome/index.html.haml
@@ -7,6 +7,7 @@
 %ul
   %li= link_to 'pages/index (just tree)',           pages_path
   %li= link_to 'pages/nested_options',              nested_options_pages_path
+  %li= link_to 'pages/indented_options',            indented_options_pages_path
   %li= link_to 'pages/manage (sortable tree)',      manage_pages_path
   %li= link_to 'pages/node_manage (sortable tree)', node_manage_pages_path
   %li= link_to 'pages/expand (expandable tree)',    expand_pages_path
@@ -16,6 +17,7 @@
 %ul
   %li= link_to '/admin/pages/index (just tree)',           admin_pages_path
   %li= link_to '/admin/pages/nested_options',              nested_options_admin_pages_path
+  %li= link_to '/admin/pages/indented_options',            indented_options_admin_pages_path
   %li= link_to '/admin/pages/manage (sortable tree)',      manage_admin_pages_path
   %li= link_to '/admin/pages/node_manage (sortable tree)', node_manage_admin_pages_path
 

--- a/spec/dummy_app/config/routes.rb
+++ b/spec/dummy_app/config/routes.rb
@@ -8,6 +8,7 @@ TheSortableTreeTest::Application.routes.draw do
   resources :pages do
     collection do
       get  :nested_options
+      get  :indented_options
       get  :manage
       get  :node_manage
       get  :expand
@@ -20,7 +21,7 @@ TheSortableTreeTest::Application.routes.draw do
   namespace :admin do
     resources :pages do
       collection do
-        get  :nested_options, :manage, :node_manage
+        get  :nested_options, :indented_options, :manage, :node_manage
         post :rebuild
       end
     end


### PR DESCRIPTION
Chrome/chromium doesn't support styling option elements. This pull requests adds a new renderer for option elements that indents them with non-breakable spaces.