### PR TITLE
Use proper jQuery-UI directives for jquery-ui-rails

### DIFF
--- a/spec/dummy_app/app/assets/javascripts/application.js
+++ b/spec/dummy_app/app/assets/javascripts/application.js
@@ -7,8 +7,8 @@
 
   //= require jquery
   //= require jquery_ujs
-  //= require jquery.ui.core
-  //= require jquery.ui.sortable
+  //= require jquery-ui/core
+  //= require jquery-ui/sortable
   
   //= require jquery.ui.nestedSortable
   //= require sortable_tree/initializer


### PR DESCRIPTION
The old form was fine for static javascript asset files, but with jquery-ui-rails the spelling is a little different.