### PR TITLE
moves rails dependency to development

### DIFF
--- a/the_sortable_tree.gemspec
+++ b/the_sortable_tree.gemspec
@@ -18,8 +18,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "rails", ">= 3.1"
-
+  s.add_development_dependency "rails", ">= 3.1"
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec"
   s.add_development_dependency "rspec-rails"


### PR DESCRIPTION
Having a rails dependency is redundant because this gem is designed to be included in a rails application. By specifying an explicit dependency, it will actually load rails again into the gemfile.lock. See the following screenshot:

https://www.dropbox.com/s/xir8fwidvtcpkz2/Screenshot%202015-09-19%2018.11.31.png?dl=0

That is inside of a rails 4.2 app. So we actually are including two versions of rails into this application because of the explicit dependency. The solution was to require Rails as a development dependency and not a production dependency.