### PR TITLE
Fixes #84

### DIFF
--- a/app/helpers/the_sortable_tree_helper.rb
+++ b/app/helpers/the_sortable_tree_helper.rb
@@ -110,8 +110,10 @@ module TheSortableTreeHelper
 
       # define roots, if it's need
       if roots.nil? && !tree.empty?
-        min_parent_id = tree.map(&:parent_id).compact.min
-        roots = tree.select{ |elem| elem.parent_id == min_parent_id }
+        ids = tree.map(&:id)
+        opt_ids = opts[:boost].keys.map(&:to_i)
+        candidate_ids = (ids+opt_ids).uniq - (ids&opt_ids) #xor
+        roots = candidate_ids.map {|c| opts[:boost][c.to_s]}.compact.flatten
       end
 
       # children rendering


### PR DESCRIPTION
Considering the setup mentioned in the beginning, this PR determines the roots to be rendered correctly.

**`XoR`** for `node_ids` and `parent_ids` is used to determine all `Node#id` which are either a **root** or a **leaf**. 
Then, `opts[:boost]` is used to check which of the nodes (which are either root or leaf) are root nodes for the tree (or sub tree)

This leverages the previously built `opts[:boost]` ID-Hash, where each Node is mapped to his corresponding `parent_id`. 

A leaf will not be present in this hash, because it will never act as a parent.
