### PR TITLE
add req for jquery-ui/sortable to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Sortable GUI require JQuery libs
 Add next JS only for Sortable GUI
 
 ```ruby
+//= require jquery-ui/sortable
 //= require jquery.ui.nestedSortable
 //= require sortable_tree/initializer
 ```
@@ -97,7 +98,7 @@ end
 ```ruby
 class Page < ActiveRecord::Base
   include TheSortableTree::Scopes
-  
+
   # any code here
 end
 ```


### PR DESCRIPTION
Fixes an issue in the documentation where jquery-ui/sortable is  missing from the requirements. If this library is not included, the sortable tree will render but not function, throwing an Unknown Method javascript error