### PR TITLE
Improves render performance during root selection

### DIFF
--- a/app/helpers/the_sortable_tree_helper.rb
+++ b/app/helpers/the_sortable_tree_helper.rb
@@ -116,7 +116,7 @@ module TheSortableTreeHelper
         ids = tree.map(&:id)
         opt_ids = opts[:boost].keys.map(&:to_i)
         candidate_ids = (ids + opt_ids).uniq - (ids & opt_ids) # xor
-        roots = candidate_ids.map {|c| opts[:boost][c.to_s]}.compact.flatten
+        roots = (candidate_ids & opt_ids).map {|c| opts[:boost][c.to_s]}.flatten
       end
 
       # children rendering


### PR DESCRIPTION
In :199 we select the roots by loading all values of `opts[:boost][c.to_s]`  where `c.to_s` is an existing parent. If it does not exist as parent we get `nil` and throw that out with `.compact` in the end.

But we can use `&` beforehand to only loop through the ids that are present as parent, thus having fewer loops and removing the need to run `.compact`.